### PR TITLE
Point to library in main of package.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+require ('./src/mdPickers');
+
+module.exports = 'mdPickers';

--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
-require ('./src/mdPickers');
+require ('./dist/mdPickers');
 
 module.exports = 'mdPickers';

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mdPickers",
   "version": "0.7.2",
   "description": "Material Design date/time pickers for Angular Material",
-  "main": "gulpfile.js",
+  "main": "index",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
This PR allows the library to be imported using module loaders whose syntax is `require(<module-name>)` by pointing to `index.js` rather than `gulpfile.js` in the `main` field of `package.json`. The usage of `index.js` as an intermediary (rather than directly pointing to the library itself) is a convention used by AngularJS and ngMaterial that allows for easier dependency management. 