### PR TITLE
Feature/set dialog labels via options

### DIFF
--- a/src/components/mdpDatePicker/mdpDatePicker.js
+++ b/src/components/mdpDatePicker/mdpDatePicker.js
@@ -9,26 +9,26 @@ function DatePickerCtrl($scope, $mdDialog, $mdMedia, $timeout, currentDate, opti
     this.displayFormat = options.displayFormat || "ddd, MMM DD";
     this.dateFilter = angular.isFunction(options.dateFilter) ? options.dateFilter : null;
     this.selectingYear = false;
-    
+
     // validate min and max date
 	if (this.minDate && this.maxDate) {
 		if (this.maxDate.isBefore(this.minDate)) {
 			this.maxDate = moment(this.minDate).add(1, 'days');
 		}
 	}
-	
+
 	if (this.date) {
 		// check min date
     	if (this.minDate && this.date.isBefore(this.minDate)) {
 			this.date = moment(this.minDate);
     	}
-    	
+
     	// check max date
     	if (this.maxDate && this.date.isAfter(this.maxDate)) {
 			this.date = moment(this.maxDate);
     	}
 	}
-	
+
 	this.yearItems = {
         currentIndex_: 0,
         PAGE_SIZE: 5,
@@ -37,7 +37,7 @@ function DatePickerCtrl($scope, $mdDialog, $mdMedia, $timeout, currentDate, opti
         getItemAtIndex: function(index) {
         	if(this.currentIndex_ < index)
                 this.currentIndex_ = index;
-        	
+
         	return this.START + index;
         },
         getLength: function() {
@@ -57,13 +57,13 @@ function DatePickerCtrl($scope, $mdDialog, $mdMedia, $timeout, currentDate, opti
         self.selectingYear = false;
         self.animate();
     };
-    
-    this.showYear = function() { 
+
+    this.showYear = function() {
         self.yearTopIndex = (self.date.year() - self.yearItems.START) + Math.floor(self.yearItems.PAGE_SIZE / 2);
         self.yearItems.currentIndex_ = (self.date.year() - self.yearItems.START) + 1;
         self.selectingYear = true;
     };
-    
+
     this.showCalendar = function() {
         self.selectingYear = false;
     };
@@ -74,23 +74,23 @@ function DatePickerCtrl($scope, $mdDialog, $mdMedia, $timeout, currentDate, opti
 
     this.confirm = function() {
     	var date = this.date;
-    	
+
     	if (this.minDate && this.date.isBefore(this.minDate)) {
     		date = moment(this.minDate);
     	}
-    	
+
     	if (this.maxDate && this.date.isAfter(this.maxDate)) {
     		date = moment(this.maxDate);
-    	}  	
-    	
+    	}
+
         $mdDialog.hide(date.toDate());
     };
-    
+
     this.animate = function() {
         self.animating = true;
         $timeout(angular.noop).then(function() {
             self.animating = false;
-        })  
+        })
     };
 }
 
@@ -98,26 +98,28 @@ module.provider("$mdpDatePicker", function() {
     var LABEL_OK = "OK",
         LABEL_CANCEL = "Cancel",
         DISPLAY_FORMAT = "ddd, MMM DD";
-        
+
     this.setDisplayFormat = function(format) {
-        DISPLAY_FORMAT = format;    
+        DISPLAY_FORMAT = format;
     };
-        
+
     this.setOKButtonLabel = function(label) {
         LABEL_OK = label;
     };
-    
+
     this.setCancelButtonLabel = function(label) {
         LABEL_CANCEL = label;
     };
-    
+
     this.$get = ["$mdDialog", function($mdDialog) {
         var datePicker = function(currentDate, options) {
             if (!angular.isDate(currentDate)) currentDate = Date.now();
             if (!angular.isObject(options)) options = {};
-            
+
+            if (options.labelCancel) LABEL_CANCEL = options.labelCancel;
+			if (options.labelOk) LABEL_OK = options.labelOk;
             options.displayFormat = DISPLAY_FORMAT;
-    
+
             return $mdDialog.show({
                 controller:  ['$scope', '$mdDialog', '$mdMedia', '$timeout', 'currentDate', 'options', DatePickerCtrl],
                 controllerAs: 'datepicker',
@@ -128,9 +130,9 @@ module.provider("$mdpDatePicker", function() {
                                     '<md-toolbar layout-align="start start" flex class="mdp-datepicker-date-wrapper md-hue-1 md-primary" layout="column">' +
                                         '<span class="mdp-datepicker-year" ng-click="datepicker.showYear()" ng-class="{ \'active\': datepicker.selectingYear }">{{ datepicker.date.format(\'YYYY\') }}</span>' +
                                         '<span class="mdp-datepicker-date" ng-click="datepicker.showCalendar()" ng-class="{ \'active\': !datepicker.selectingYear }">{{ datepicker.date.format(datepicker.displayFormat) }}</span> ' +
-                                    '</md-toolbar>' + 
-                                '</div>' +  
-                                '<div>' + 
+                                    '</md-toolbar>' +
+                                '</div>' +
+                                '<div>' +
                                     '<div class="mdp-datepicker-select-year mdp-animation-zoom" layout="column" layout-align="center start" ng-if="datepicker.selectingYear">' +
                                         '<md-virtual-repeat-container md-auto-shrink md-top-index="datepicker.yearTopIndex">' +
                                             '<div flex md-virtual-repeat="item in datepicker.yearItems" md-on-demand class="repeated-year">' +
@@ -155,7 +157,7 @@ module.provider("$mdpDatePicker", function() {
                 skipHide: true
             });
         };
-    
+
         return datePicker;
     }];
 });
@@ -163,25 +165,25 @@ module.provider("$mdpDatePicker", function() {
 function CalendarCtrl($scope) {
 	var self = this;
 	this.dow = moment.localeData().firstDayOfWeek();
-	
+
     this.weekDays = [].concat(
         moment.weekdaysMin().slice(
             this.dow
         ),
         moment.weekdaysMin().slice(
-            0, 
+            0,
             this.dow
         )
     );
-    
+
     this.daysInMonth = [];
-    
+
     this.getDaysInMonth = function() {
         var days = self.date.daysInMonth(),
             firstDay = moment(self.date).date(1).day() - this.dow;
-            
+
         if(firstDay < 0) firstDay = this.weekDays.length - 1;
-            
+
 
         var arr = [];
         for(var i = 1; i <= (firstDay + days); i++) {
@@ -194,16 +196,16 @@ function CalendarCtrl($scope) {
             }
             arr.push(day);
         }
- 
+
         return arr;
     };
-    
+
     this.isDayEnabled = function(day) {
-        return (!this.minDate || this.minDate <= day) && 
-            (!this.maxDate || this.maxDate >= day) && 
+        return (!this.minDate || this.minDate <= day) &&
+            (!this.maxDate || this.maxDate >= day) &&
             (!self.dateFilter || !self.dateFilter(day));
     };
-    
+
     this.selectDate = function(dom) {
         self.date.date(dom);
     };
@@ -215,16 +217,16 @@ function CalendarCtrl($scope) {
     this.prevMonth = function() {
         self.date.subtract(1, 'months');
     };
-    
+
     this.updateDaysInMonth = function() {
         self.daysInMonth = self.getDaysInMonth();
     };
-    
+
     $scope.$watch(function() { return  self.date.unix() }, function(newValue, oldValue) {
         if(newValue && newValue !== oldValue)
             self.updateDaysInMonth();
     })
-    
+
     self.updateDaysInMonth();
 }
 
@@ -261,17 +263,17 @@ module.directive("mdpCalendar", ["$animate", function($animate) {
                 element[0].querySelector('.mdp-calendar-days'),
                 element[0].querySelector('.mdp-calendar-monthyear')
             ].map(function(a) {
-               return angular.element(a); 
+               return angular.element(a);
             });
-                
+
             scope.$watch(function() { return  ctrl.date.format("YYYYMM") }, function(newValue, oldValue) {
                 var direction = null;
-                
+
                 if(newValue > oldValue)
                     direction = "mdp-animate-next";
                 else if(newValue < oldValue)
                     direction = "mdp-animate-prev";
-                
+
                 if(direction) {
                     for(var i in animElements) {
                         animElements[i].addClass(direction);
@@ -290,29 +292,29 @@ function formatValidator(value, format) {
 function minDateValidator(value, format, minDate) {
     var minDate = moment(minDate, "YYYY-MM-DD", true);
     var date = angular.isDate(value) ? moment(value) :  moment(value, format, true);
-    
-    return !value || 
-            angular.isDate(value) || 
-            !minDate.isValid() || 
+
+    return !value ||
+            angular.isDate(value) ||
+            !minDate.isValid() ||
             date.isSameOrAfter(minDate);
 }
 
 function maxDateValidator(value, format, maxDate) {
     var maxDate = moment(maxDate, "YYYY-MM-DD", true);
     var date = angular.isDate(value) ? moment(value) :  moment(value, format, true);
-    
-    return !value || 
-            angular.isDate(value) || 
-            !maxDate.isValid() || 
+
+    return !value ||
+            angular.isDate(value) ||
+            !maxDate.isValid() ||
             date.isSameOrBefore(maxDate);
 }
 
 function filterValidator(value, format, filter) {
     var date = angular.isDate(value) ? moment(value) :  moment(value, format, true);
-                
-    return !value || 
-            angular.isDate(value) || 
-            !angular.isFunction(filter) || 
+
+    return !value ||
+            angular.isDate(value) ||
+            !angular.isFunction(filter) ||
             !filter(date);
 }
 
@@ -329,7 +331,7 @@ module.directive("mdpDatePicker", ["$mdpDatePicker", "$timeout", function($mdpDa
             var noFloat = angular.isDefined(attrs.mdpNoFloat),
                 placeholder = angular.isDefined(attrs.mdpPlaceholder) ? attrs.mdpPlaceholder : "",
                 openOnClick = angular.isDefined(attrs.mdpOpenOnClick) ? true : false;
-            
+
             return '<div layout layout-align="start start">' +
                     '<md-button' + (angular.isDefined(attrs.mdpDisabled) ? ' ng-disabled="disabled"' : '') + ' class="md-icon-button" ng-click="showPicker($event)">' +
                         '<md-icon md-svg-icon="mdp-event"></md-icon>' +
@@ -351,56 +353,56 @@ module.directive("mdpDatePicker", ["$mdpDatePicker", "$timeout", function($mdpDa
         },
         link: {
             pre: function(scope, element, attrs, ngModel, $transclude) {
-                
+
             },
             post: function(scope, element, attrs, ngModel, $transclude) {
                 var inputElement = angular.element(element[0].querySelector('input')),
                     inputContainer = angular.element(element[0].querySelector('md-input-container')),
                     inputContainerCtrl = inputContainer.controller("mdInputContainer");
-                    
+
                 $transclude(function(clone) {
-                   inputContainer.append(clone); 
-                });  
-                
+                   inputContainer.append(clone);
+                });
+
                 var messages = angular.element(inputContainer[0].querySelector("[ng-messages]"));
-                
+
                 scope.type = scope.dateFormat ? "text" : "date"
                 scope.dateFormat = scope.dateFormat || "YYYY-MM-DD";
                 scope.model = ngModel;
-                
+
                 scope.isError = function() {
                     return !ngModel.$pristine && !!ngModel.$invalid;
                 };
-                
+
                 // update input element if model has changed
                 ngModel.$formatters.unshift(function(value) {
                     var date = angular.isDate(value) && moment(value);
-                    if(date && date.isValid()) 
+                    if(date && date.isValid())
                         updateInputElement(date.format(scope.dateFormat));
                     else
                         updateInputElement(null);
                 });
-                
+
                 ngModel.$validators.format = function(modelValue, viewValue) {
                     return formatValidator(viewValue, scope.dateFormat);
                 };
-                
+
                 ngModel.$validators.minDate = function(modelValue, viewValue) {
                     return minDateValidator(viewValue, scope.dateFormat, scope.minDate);
                 };
-                
+
                 ngModel.$validators.maxDate = function(modelValue, viewValue) {
                     return maxDateValidator(viewValue, scope.dateFormat, scope.maxDate);
                 };
-                
+
                 ngModel.$validators.filter = function(modelValue, viewValue) {
                     return filterValidator(viewValue, scope.dateFormat, scope.dateFilter);
                 };
-                
+
                 ngModel.$validators.required = function(modelValue, viewValue) {
                     return angular.isUndefined(attrs.required) || !ngModel.$isEmpty(modelValue) || !ngModel.$isEmpty(viewValue);
                 };
-                
+
                 ngModel.$parsers.unshift(function(value) {
                     var parsed = moment(value, scope.dateFormat, true);
                     if(parsed.isValid()) {
@@ -409,24 +411,24 @@ module.directive("mdpDatePicker", ["$mdpDatePicker", "$timeout", function($mdpDa
                             originalModel.year(parsed.year());
                             originalModel.month(parsed.month());
                             originalModel.date(parsed.date());
-                            
+
                             parsed = originalModel;
                         }
-                        return parsed.toDate(); 
+                        return parsed.toDate();
                     } else
                         return null;
                 });
-                
+
                 // update input element value
                 function updateInputElement(value) {
                     inputElement[0].value = value;
                     inputContainerCtrl.setHasValue(!ngModel.$isEmpty(value));
                 }
-                
+
                 function updateDate(date) {
                     var value = moment(date, angular.isDate(date) ? null : scope.dateFormat, true),
                         strValue = value.format(scope.dateFormat);
-    
+
                     if(value.isValid()) {
                         updateInputElement(strValue);
                         ngModel.$setViewValue(strValue);
@@ -434,30 +436,30 @@ module.directive("mdpDatePicker", ["$mdpDatePicker", "$timeout", function($mdpDa
                         updateInputElement(date);
                         ngModel.$setViewValue(date);
                     }
-                    
-                    if(!ngModel.$pristine && 
-                        messages.hasClass("md-auto-hide") && 
+
+                    if(!ngModel.$pristine &&
+                        messages.hasClass("md-auto-hide") &&
                         inputContainer.hasClass("md-input-invalid")) messages.removeClass("md-auto-hide");
-    
+
                     ngModel.$render();
                 }
-                    
+
                 scope.showPicker = function(ev) {
                     $mdpDatePicker(ngModel.$modelValue, {
-                	    minDate: scope.minDate, 
+                	    minDate: scope.minDate,
                 	    maxDate: scope.maxDate,
                 	    dateFilter: scope.dateFilter,
                 	    targetEvent: ev
             	    }).then(updateDate);
                 };
-                
+
                 function onInputElementEvents(event) {
                     if(event.target.value !== ngModel.$viewVaue)
                         updateDate(event.target.value);
                 }
-                
+
                 inputElement.on("reset input blur", onInputElementEvents);
-                
+
                 scope.$on("$destroy", function() {
                     inputElement.off("reset input blur", onInputElementEvents);
                 });
@@ -479,26 +481,26 @@ module.directive("mdpDatePicker", ["$mdpDatePicker", "$timeout", function($mdpDa
         },
         link: function(scope, element, attrs, ngModel, $transclude) {
             scope.dateFormat = scope.dateFormat || "YYYY-MM-DD";
-            
+
             ngModel.$validators.format = function(modelValue, viewValue) {
                 return formatValidator(viewValue, scope.format);
             };
-            
+
             ngModel.$validators.minDate = function(modelValue, viewValue) {
                 return minDateValidator(viewValue, scope.format, scope.minDate);
             };
-            
+
             ngModel.$validators.maxDate = function(modelValue, viewValue) {
                 return maxDateValidator(viewValue, scope.format, scope.maxDate);
             };
-            
+
             ngModel.$validators.filter = function(modelValue, viewValue) {
                 return filterValidator(viewValue, scope.format, scope.dateFilter);
             };
-            
+
             function showPicker(ev) {
                 $mdpDatePicker(ngModel.$modelValue, {
-            	    minDate: scope.minDate, 
+            	    minDate: scope.minDate,
             	    maxDate: scope.maxDate,
             	    dateFilter: scope.dateFilter,
             	    targetEvent: ev
@@ -507,9 +509,9 @@ module.directive("mdpDatePicker", ["$mdpDatePicker", "$timeout", function($mdpDa
                     ngModel.$render();
                 });
             };
-            
+
             element.on("click", showPicker);
-            
+
             scope.$on("$destroy", function() {
                 element.off("click", showPicker);
             });

--- a/src/components/mdpTimePicker/mdpTimePicker.js
+++ b/src/components/mdpTimePicker/mdpTimePicker.js
@@ -7,26 +7,26 @@ function TimePickerCtrl($scope, $mdDialog, time, autoSwitch, $mdMedia) {
     this.currentView = this.VIEW_HOURS;
     this.time = moment(time);
     this.autoSwitch = !!autoSwitch;
-    
+
     this.clockHours = parseInt(this.time.format("h"));
     this.clockMinutes = parseInt(this.time.minutes());
-    
+
 	$scope.$mdMedia = $mdMedia;
-	
+
 	this.switchView = function() {
 	    self.currentView = self.currentView == self.VIEW_HOURS ? self.VIEW_MINUTES : self.VIEW_HOURS;
 	};
-    
+
 	this.setAM = function() {
         if(self.time.hours() >= 12)
             self.time.hour(self.time.hour() - 12);
 	};
-    
+
     this.setPM = function() {
         if(self.time.hours() < 12)
             self.time.hour(self.time.hour() + 12);
 	};
-    
+
     this.cancel = function() {
         $mdDialog.cancel();
     };
@@ -40,10 +40,10 @@ function ClockCtrl($scope) {
     var TYPE_HOURS = "hours";
     var TYPE_MINUTES = "minutes";
     var self = this;
-    
+
     this.STEP_DEG = 360 / 12;
     this.steps = [];
-    
+
     this.CLOCK_TYPES = {
         "hours": {
             range: 12,
@@ -52,7 +52,7 @@ function ClockCtrl($scope) {
             range: 60,
         }
     }
-    
+
     this.getPointerStyle = function() {
         var divider = 1;
         switch(self.type) {
@@ -62,15 +62,15 @@ function ClockCtrl($scope) {
             case TYPE_MINUTES:
                 divider = 60;
                 break;
-        }  
+        }
         var degrees = Math.round(self.selected * (360 / divider)) - 180;
-        return { 
+        return {
             "-webkit-transform": "rotate(" + degrees + "deg)",
             "-ms-transform": "rotate(" + degrees + "deg)",
             "transform": "rotate(" + degrees + "deg)"
         }
     };
-    
+
     this.setTimeByDeg = function(deg) {
         deg = deg >= 360 ? 0 : deg;
         var divider = 0;
@@ -81,16 +81,16 @@ function ClockCtrl($scope) {
             case TYPE_MINUTES:
                 divider = 60;
                 break;
-        }  
-        
+        }
+
         self.setTime(
             Math.round(divider / 360 * deg)
         );
     };
-    
+
     this.setTime = function(time, type) {
         this.selected = time;
-        
+
         switch(self.type) {
             case TYPE_HOURS:
                 if(self.time.format("A") == "PM") time += 12;
@@ -101,9 +101,9 @@ function ClockCtrl($scope) {
                 this.time.minutes(time);
                 break;
         }
-        
+
     };
-    
+
     this.init = function() {
         self.type = self.type || "hours";
         switch(self.type) {
@@ -112,18 +112,18 @@ function ClockCtrl($scope) {
                     self.steps.push(i);
                 self.selected = self.time.hours() || 0;
                 if(self.selected > 12) self.selected -= 12;
-                    
+
                 break;
             case TYPE_MINUTES:
                 for(var i = 5; i <= 55; i+=5)
                     self.steps.push(i);
                 self.steps.push(0);
                 self.selected = self.time.minutes() || 0;
-                
+
                 break;
         }
     };
-    
+
     this.init();
 }
 
@@ -150,7 +150,7 @@ module.directive("mdpClock", ["$animate", "$timeout", function($animate, $timeou
         link: function(scope, element, attrs, ctrl) {
             var pointer = angular.element(element[0].querySelector(".mdp-pointer")),
                 timepickerCtrl = scope.$parent.timepicker;
-            
+
             var onEvent = function(event) {
                 var containerCoords = event.currentTarget.getClientRects()[0];
                 var x = ((event.currentTarget.offsetWidth / 2) - (event.pageX - containerCoords.left)),
@@ -161,20 +161,20 @@ module.directive("mdpClock", ["$animate", "$timeout", function($animate, $timeou
                     ctrl.setTimeByDeg(deg + 180);
                     if(ctrl.autoSwitch && ["mouseup", "click"].indexOf(event.type) !== -1 && timepickerCtrl) timepickerCtrl.switchView();
                 });
-            }; 
-            
+            };
+
             element.on("mousedown", function() {
                element.on("mousemove", onEvent);
             });
-            
+
             element.on("mouseup", function(e) {
                 element.off("mousemove");
             });
-            
+
             element.on("click", onEvent);
             scope.$on("$destroy", function() {
                 element.off("click", onEvent);
-                element.off("mousemove", onEvent); 
+                element.off("mousemove", onEvent);
             });
         }
     }
@@ -183,20 +183,23 @@ module.directive("mdpClock", ["$animate", "$timeout", function($animate, $timeou
 module.provider("$mdpTimePicker", function() {
     var LABEL_OK = "OK",
         LABEL_CANCEL = "Cancel";
-        
+
     this.setOKButtonLabel = function(label) {
         LABEL_OK = label;
     };
-    
+
     this.setCancelButtonLabel = function(label) {
         LABEL_CANCEL = label;
     };
-    
+
     this.$get = ["$mdDialog", function($mdDialog) {
         var timePicker = function(time, options) {
             if(!angular.isDate(time)) time = Date.now();
             if (!angular.isObject(options)) options = {};
-    
+
+			if (options.labelCancel) LABEL_CANCEL = options.labelCancel;
+			if (options.labelOk) LABEL_OK = options.labelOk;
+
             return $mdDialog.show({
                 controller:  ['$scope', '$mdDialog', 'time', 'autoSwitch', '$mdMedia', TimePickerCtrl],
                 controllerAs: 'timepicker',
@@ -205,20 +208,20 @@ module.provider("$mdpTimePicker", function() {
                             '<md-dialog-content layout-gt-xs="row" layout-wrap>' +
                                 '<md-toolbar layout-gt-xs="column" layout-xs="row" layout-align="center center" flex class="mdp-timepicker-time md-hue-1 md-primary">' +
                                     '<div class="mdp-timepicker-selected-time">' +
-                                        '<span ng-class="{ \'active\': timepicker.currentView == timepicker.VIEW_HOURS }" ng-click="timepicker.currentView = timepicker.VIEW_HOURS">{{ timepicker.time.format("h") }}</span>:' + 
+                                        '<span ng-class="{ \'active\': timepicker.currentView == timepicker.VIEW_HOURS }" ng-click="timepicker.currentView = timepicker.VIEW_HOURS">{{ timepicker.time.format("h") }}</span>:' +
                                         '<span ng-class="{ \'active\': timepicker.currentView == timepicker.VIEW_MINUTES }" ng-click="timepicker.currentView = timepicker.VIEW_MINUTES">{{ timepicker.time.format("mm") }}</span>' +
                                     '</div>' +
-                                    '<div layout="column" class="mdp-timepicker-selected-ampm">' + 
+                                    '<div layout="column" class="mdp-timepicker-selected-ampm">' +
                                         '<span ng-click="timepicker.setAM()" ng-class="{ \'active\': timepicker.time.hours() < 12 }">AM</span>' +
                                         '<span ng-click="timepicker.setPM()" ng-class="{ \'active\': timepicker.time.hours() >= 12 }">PM</span>' +
-                                    '</div>' + 
+                                    '</div>' +
                                 '</md-toolbar>' +
                                 '<div>' +
                                     '<div class="mdp-clock-switch-container" ng-switch="timepicker.currentView" layout layout-align="center center">' +
 	                                    '<mdp-clock class="mdp-animation-zoom" auto-switch="timepicker.autoSwitch" time="timepicker.time" type="hours" ng-switch-when="1"></mdp-clock>' +
 	                                    '<mdp-clock class="mdp-animation-zoom" auto-switch="timepicker.autoSwitch" time="timepicker.time" type="minutes" ng-switch-when="2"></mdp-clock>' +
                                     '</div>' +
-                                    
+
                                     '<md-dialog-actions layout="row">' +
 	                                	'<span flex></span>' +
                                         '<md-button ng-click="timepicker.cancel()" aria-label="' + LABEL_CANCEL + '">' + LABEL_CANCEL + '</md-button>' +
@@ -235,7 +238,7 @@ module.provider("$mdpTimePicker", function() {
                 skipHide: true
             });
         };
-    
+
         return timePicker;
     }];
 });
@@ -249,7 +252,7 @@ module.directive("mdpTimePicker", ["$mdpTimePicker", "$timeout", function($mdpTi
             var noFloat = angular.isDefined(attrs.mdpNoFloat),
                 placeholder = angular.isDefined(attrs.mdpPlaceholder) ? attrs.mdpPlaceholder : "",
                 openOnClick = angular.isDefined(attrs.mdpOpenOnClick) ? true : false;
-            
+
             return '<div layout layout-align="start start">' +
                     '<md-button class="md-icon-button" ng-click="showPicker($event)"' + (angular.isDefined(attrs.mdpDisabled) ? ' ng-disabled="disabled"' : '') + '>' +
                         '<md-icon md-svg-icon="mdp-access-time"></md-icon>' +
@@ -269,38 +272,38 @@ module.directive("mdpTimePicker", ["$mdpTimePicker", "$timeout", function($mdpTi
             var inputElement = angular.element(element[0].querySelector('input')),
                 inputContainer = angular.element(element[0].querySelector('md-input-container')),
                 inputContainerCtrl = inputContainer.controller("mdInputContainer");
-                
+
             $transclude(function(clone) {
-               inputContainer.append(clone); 
+               inputContainer.append(clone);
             });
-            
+
             var messages = angular.element(inputContainer[0].querySelector("[ng-messages]"));
-            
+
             scope.type = scope.timeFormat ? "text" : "time"
             scope.timeFormat = scope.timeFormat || "HH:mm";
             scope.autoSwitch = scope.autoSwitch || false;
-            
+
             scope.$watch(function() { return ngModel.$error }, function(newValue, oldValue) {
                 inputContainerCtrl.setInvalid(!ngModel.$pristine && !!Object.keys(ngModel.$error).length);
             }, true);
-            
+
             // update input element if model has changed
             ngModel.$formatters.unshift(function(value) {
                 var time = angular.isDate(value) && moment(value);
-                if(time && time.isValid()) 
+                if(time && time.isValid())
                     updateInputElement(time.format(scope.timeFormat));
                 else
                     updateInputElement(null);
             });
-            
+
             ngModel.$validators.format = function(modelValue, viewValue) {
                 return !viewValue || angular.isDate(viewValue) || moment(viewValue, scope.timeFormat, true).isValid();
             };
-            
+
             ngModel.$validators.required = function(modelValue, viewValue) {
                 return angular.isUndefined(attrs.required) || !ngModel.$isEmpty(modelValue) || !ngModel.$isEmpty(viewValue);
             };
-            
+
             ngModel.$parsers.unshift(function(value) {
                 var parsed = moment(value, scope.timeFormat, true);
                 if(parsed.isValid()) {
@@ -309,20 +312,20 @@ module.directive("mdpTimePicker", ["$mdpTimePicker", "$timeout", function($mdpTi
                         originalModel.minutes(parsed.minutes());
                         originalModel.hours(parsed.hours());
                         originalModel.seconds(parsed.seconds());
-                        
+
                         parsed = originalModel;
                     }
-                    return parsed.toDate(); 
+                    return parsed.toDate();
                 } else
                     return null;
             });
-            
+
             // update input element value
             function updateInputElement(value) {
                 inputElement[0].value = value;
                 inputContainerCtrl.setHasValue(!ngModel.$isEmpty(value));
             }
-            
+
             function updateTime(time) {
                 var value = moment(time, angular.isDate(time) ? null : scope.timeFormat, true),
                     strValue = value.format(scope.timeFormat);
@@ -334,14 +337,14 @@ module.directive("mdpTimePicker", ["$mdpTimePicker", "$timeout", function($mdpTi
                     updateInputElement(time);
                     ngModel.$setViewValue(time);
                 }
-                
-                if(!ngModel.$pristine && 
-                    messages.hasClass("md-auto-hide") && 
+
+                if(!ngModel.$pristine &&
+                    messages.hasClass("md-auto-hide") &&
                     inputContainer.hasClass("md-input-invalid")) messages.removeClass("md-auto-hide");
-                
+
                 ngModel.$render();
             }
-                
+
             scope.showPicker = function(ev) {
                 $mdpTimePicker(ngModel.$modelValue, {
                     targetEvent: ev,
@@ -350,14 +353,14 @@ module.directive("mdpTimePicker", ["$mdpTimePicker", "$timeout", function($mdpTi
                     updateTime(time, true);
                 });
             };
-            
+
             function onInputElementEvents(event) {
                 if(event.target.value !== ngModel.$viewVaue)
                     updateTime(event.target.value);
             }
-            
+
             inputElement.on("reset input blur", onInputElementEvents);
-            
+
             scope.$on("$destroy", function() {
                 inputElement.off("reset input blur", onInputElementEvents);
             })
@@ -384,9 +387,9 @@ module.directive("mdpTimePicker", ["$mdpTimePicker", "$timeout", function($mdpTi
                     ngModel.$render();
                 });
             };
-            
+
             element.on("click", showPicker);
-            
+
             scope.$on("$destroy", function() {
                 element.off("click", showPicker);
             });


### PR DESCRIPTION
In certain scenarios I need to set the labels of the dialogs after the config phase (e.g. the language has been changed by the user).

To achieve this, I've added the ability to set the label though the `options` passed to `$mdpDatePicker` and `$mdpTimePicker`.
