### PR TITLE
Update mdpDatePicker.js

### DIFF
--- a/src/components/mdpDatePicker/mdpDatePicker.js
+++ b/src/components/mdpDatePicker/mdpDatePicker.js
@@ -335,7 +335,7 @@ module.directive("mdpDatePicker", ["$mdpDatePicker", "$timeout", function($mdpDa
                         '<md-icon md-svg-icon="mdp-event"></md-icon>' +
                     '</md-button>' +
                     '<md-input-container' + (noFloat ? ' md-no-float' : '') + ' md-is-error="isError()">' +
-                        '<input type="{{ ::type }}"' + (angular.isDefined(attrs.mdpDisabled) ? ' ng-disabled="disabled"' : '') + ' aria-label="' + placeholder + '" placeholder="' + placeholder + '"' + (openOnClick ? ' ng-click="showPicker($event)" ' : '') + ' />' +
+                        '<input type="{{ ::type }}"' + (angular.isDefined(attrs.mdpDisabled) ? ' ng-disabled="disabled"' : '') + ' aria-label="' + placeholder + '" placeholder="' + placeholder + '"' + (openOnClick ? ' ng-click="showPicker($event)" readonly ' : '') + ' />' +
                     '</md-input-container>' +
                 '</div>';
         },


### PR DESCRIPTION
mdpOpenOnClick on device open native DateTime, by adding readonly to input it allows mdPickers to be opened.