### PR TITLE
Update mdpTimePicker.js

### DIFF
--- a/src/components/mdpTimePicker/mdpTimePicker.js
+++ b/src/components/mdpTimePicker/mdpTimePicker.js
@@ -255,7 +255,7 @@ module.directive("mdpTimePicker", ["$mdpTimePicker", "$timeout", function($mdpTi
                         '<md-icon md-svg-icon="mdp-access-time"></md-icon>' +
                     '</md-button>' +
                     '<md-input-container' + (noFloat ? ' md-no-float' : '') + ' md-is-error="isError()">' +
-                        '<input type="{{ ::type }}"' + (angular.isDefined(attrs.mdpDisabled) ? ' ng-disabled="disabled"' : '') + ' aria-label="' + placeholder + '" placeholder="' + placeholder + '"' + (openOnClick ? ' ng-click="showPicker($event)" ' : '') + ' />' +
+                        '<input type="{{ ::type }}"' + (angular.isDefined(attrs.mdpDisabled) ? ' ng-disabled="disabled"' : '') + ' aria-label="' + placeholder + '" placeholder="' + placeholder + '"' + (openOnClick ? ' ng-click="showPicker($event)" readonly ' : '') + ' />' +
                     '</md-input-container>' +
                 '</div>';
         },


### PR DESCRIPTION
mdpOpenOnClick on device open native Time picker, by adding readonly to input it allows only mdPickers to be opened.